### PR TITLE
Add option to keep file history and respect user's trashing behavior preference

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -752,10 +752,7 @@ export default class EditHistory extends Plugin {
             let zipFile = this.app.vault.getAbstractFileByPath(zipFilepath);
             if (zipFile != null) {
                 logInfo("Deleting edit history file", zipFilepath);
-                // XXX Should this trash instead of delete? (the Obsidian
-                //     setting under Files and Links allows choosing between
-                //     system trash, obsidian trash and delete)
-                this.app.vault.delete(zipFile);
+                this.app.fileManager.trashFile(zipFile);
             }
         }));
 

--- a/main.ts
+++ b/main.ts
@@ -739,10 +739,6 @@ export default class EditHistory extends Plugin {
             logInfo("vault delete path", file.path);
             // This reports any files or folders modified via the api, ignore
             // non whitelisted files/folders
-            if (this.settings.keepDeletedFileHistory) {
-                logDbg("Keeping history for deleted file", file.path);
-                return;
-            }            
             if (!(this.keepEditHistoryForFile(file))) {
                 logDbg("Ignoring non whitelisted file", file.path);
                 return;
@@ -750,6 +746,19 @@ export default class EditHistory extends Plugin {
             // Delete the edit history file if any
             let zipFilepath = this.getEditHistoryFilepath(file.path);
             let zipFile = this.app.vault.getAbstractFileByPath(zipFilepath);
+            if (zipFile && this.settings.keepDeletedFileHistory) {
+                logDbg("Keeping history for deleted file", file.path);
+                const now = new Date();
+                const timestamp = now.getFullYear() +
+                    String(now.getMonth() + 1).padStart(2, "0") +
+                    String(now.getDate()).padStart(2, "0") +
+                    String(now.getHours()).padStart(2, "0") +
+                    String(now.getMinutes()).padStart(2, "0") +
+                    String(now.getSeconds()).padStart(2, "0");
+                zipFilepath = zipFilepath.replace(".edtz", `.${timestamp}.edtz`);
+                this.app.vault.rename(zipFile, zipFilepath);
+                return;
+            }            
             if (zipFile != null) {
                 logInfo("Deleting edit history file", zipFilepath);
                 this.app.fileManager.trashFile(zipFile);

--- a/main.ts
+++ b/main.ts
@@ -118,6 +118,7 @@ interface EditHistorySettings {
     editHistoryRootFolder: string;
     extensionWhitelist: string;
     substringBlacklist: string;
+    keepDeletedFileHistory: boolean;
     showOnStatusBar: boolean;
     diffDisplayFormat: string;
     showWhitespace: boolean;
@@ -133,6 +134,7 @@ const DEFAULT_SETTINGS: EditHistorySettings = {
     editHistoryRootFolder: "",
     extensionWhitelist: ".md, .txt, .csv, .htm, .html",
     substringBlacklist: "",
+    keepDeletedFileHistory: true,
     showOnStatusBar: true,
     diffDisplayFormat: DiffDisplayFormat.Inline,
     showWhitespace: true,
@@ -737,6 +739,10 @@ export default class EditHistory extends Plugin {
             logInfo("vault delete path", file.path);
             // This reports any files or folders modified via the api, ignore
             // non whitelisted files/folders
+            if (this.settings.keepDeletedFileHistory) {
+                logDbg("Keeping history for deleted file", file.path);
+                return;
+            }            
             if (!(this.keepEditHistoryForFile(file))) {
                 logDbg("Ignoring non whitelisted file", file.path);
                 return;
@@ -1787,6 +1793,17 @@ class EditHistorySettingTab extends PluginSettingTab { plugin:
                         this.plugin.settings.substringBlacklist = value;
                         await this.plugin.saveSettings();
                     }));
+        
+        new Setting(containerEl)
+            .setName("Keep deleted file history")
+            .setDesc("Deleted files will keep their edit history even after deletion. Disable to delete the edit history file when the original file is deleted to reduce storage.")
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.keepDeletedFileHistory)
+                .onChange(async value => {
+                    logInfo("Keep deleted file history: " + value);
+                    this.plugin.settings.keepDeletedFileHistory = value;
+                    await this.plugin.saveSettings();
+                }));
 
         containerEl.createEl("h3", {text: "Appearance"});
         new Setting(containerEl)


### PR DESCRIPTION
- Added a new configuration option to keep the history file when deleting a file.
  - To make sure a file with the exact same name as a deleted file doesn't get interpreted as another version of the old file, a timestamp is appended to the history file name.
- Addressed the behavior where history files would always get permanently deleted by swapping `this.app.vault.delete(zipFile)` for `this.app.fileManager.trashFile(zipFile)`