### PR TITLE
Add .base and .canvas to the default extension whitelist

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -131,7 +131,7 @@ const DEFAULT_SETTINGS: EditHistorySettings = {
     maxEdits: "0",
     maxHistoryFileSizeKB: "0",
     editHistoryRootFolder: "",
-    extensionWhitelist: ".md, .txt, .csv, .htm, .html",
+    extensionWhitelist: ".md, .base, .canvas, .txt, .csv, .htm, .html",
     substringBlacklist: "",
     showOnStatusBar: true,
     diffDisplayFormat: DiffDisplayFormat.Inline,


### PR DESCRIPTION
## What

Adds `.base` and `.canvas` to the default `extensionWhitelist` setting, so edit history is kept for Obsidian's core Canvas and Bases file formats out of the box:

```
.md, .base, .canvas, .txt, .csv, .htm, .html
```

## Why

Canvas (and, since Obsidian 1.9, Bases) files are first-class vault content that users edit as often as notes, but with the current default their edits are silently not tracked. Both formats are text (JSON / YAML-like), so they diff and restore cleanly.

## Notes

- No logic changes needed: history capture hooks `vault.on("modify")`, which fires for these files, and whitelist matching is a case-insensitive `endsWith`, so the two new entries just work.
- Only affects fresh installs / users who haven't customized the setting; existing saved settings are untouched.
- The settings-tab placeholder reflects the new default automatically since it reads `DEFAULT_SETTINGS.extensionWhitelist`.
- Verified with `npm run build` (tsc + esbuild production) — compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)