### PR TITLE
Fix "attempted to load NodeJS package: stream" warning on mobile

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -52,12 +52,40 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = (process.argv[2] === "production");
 
+// JSZip's browser shim resolves "readable-stream" to `require("stream")` so a
+// bundler can supply a single stream implementation. This plugin never uses
+// JSZip's node stream output (all zip I/O is arraybuffer), and when "stream" is
+// left as a runtime require Obsidian warns on mobile ("edit-history attempted
+// to load NodeJS package: stream"). Stub the stream modules to an empty object
+// so the require is gone from the bundle and the plugin loads clean on mobile.
+// JSZip is aliased to its source entry (below) so these requires are visible to
+// esbuild rather than baked into JSZip's prebuilt dist.
+const stubJszipNodeStream = {
+    name: "stub-jszip-node-stream",
+    setup(build) {
+        build.onResolve({ filter: /^(stream|readable-stream)$/ }, () => ({
+            path: "jszip-node-stream-stub",
+            namespace: "jszip-node-stream-stub",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "jszip-node-stream-stub" }, () => ({
+            contents: "module.exports = {};",
+            loader: "js",
+        }));
+    },
+};
+
 const context = await esbuild.context({
     banner: {
         js: banner,
     },
     entryPoints: ["main.ts"],
     bundle: true,
+    plugins: [stubJszipNodeStream],
+    // Bundle JSZip from its source entry, not the prebuilt dist, so the
+    // stream-stub plugin above can intercept its readable-stream/stream requires.
+    alias: {
+        "jszip": path.resolve("node_modules/jszip/lib/index.js"),
+    },
     external: [
         "obsidian",
         "electron",
@@ -78,6 +106,10 @@ const context = await esbuild.context({
     logLevel: "info",
     sourcemap: prod ? false : "inline",
     treeShaking: true,
+    // Minify production builds: JSZip is now bundled from (unminified) source
+    // instead of its prebuilt minified dist, so minifying keeps the artifact
+    // small (and smaller than the previous dist-based build).
+    minify: prod,
     outfile: "main.js",
 });
 


### PR DESCRIPTION
On mobile, opening a vault with this plugin shows a notice:

> edit-history attempted to load NodeJS package: "stream"

## Cause

JSZip's browser shim (`lib/readable-stream-browser.js`) is literally `module.exports = require("stream")` — it defers to the bundler to provide a stream implementation. The esbuild config marked all Node builtins `external` (`...builtins`), so `stream` stayed as a runtime `require("stream")` in the bundle. Obsidian intercepts that on mobile and shows the warning (it fires on load).

The plugin never uses JSZip's node stream output — all zip I/O is `arraybuffer` — so the require is only reached by JSZip's nodestream *support detection* (`require("stream").Readable`) and is otherwise dead weight.

## Fix

- Bundle JSZip from its source entry (`alias: jszip -> lib/index.js`) instead of its prebuilt browserified dist, so its `readable-stream`/`stream` requires are visible to esbuild rather than baked into the dist.
- An esbuild plugin stubs `stream`/`readable-stream` to an empty module, removing the require entirely. (`require("stream").Readable` becomes `undefined`, so JSZip just reports no nodestream support, which is correct here.)
- Minify production builds, since JSZip source is unminified. Net artifact is ~138KB, roughly half the previous ~284KB dist-based build.

Keeps `isDesktopOnly: false` — the plugin works fine on mobile, this only removes the spurious warning.

## Testing

Verified in mobile emulation:
- Before: the `attempted to load NodeJS package: "stream"` notice fires on plugin load.
- After: it no longer appears, and a create+edit+edit round-trip still writes a valid 2-entry `.edtz` (exercises both `generateAsync` and `loadAsync`) with no errors.
- `npm run build` (tsc + esbuild production) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)